### PR TITLE
Add onblur hide autocomplete choices

### DIFF
--- a/examples/src/SingleValue.elm
+++ b/examples/src/SingleValue.elm
@@ -5,6 +5,7 @@ import Autocomplete.View as AutocompleteView
 import Browser
 import Html exposing (Attribute, Html)
 import Html.Attributes
+import Html.Events
 import Task exposing (Task)
 
 
@@ -27,6 +28,7 @@ type alias Model =
 type Msg
     = OnAutocomplete (Autocomplete.Msg String)
     | OnAutocompleteSelect
+    | OnAutocompleteBlur
 
 
 fetcher : Autocomplete.Choices String -> Task String (Autocomplete.Choices String)
@@ -119,6 +121,26 @@ update msg model =
             , Cmd.none
             )
 
+        OnAutocompleteBlur ->
+            let
+                { autocompleteState } =
+                    model
+
+                query =
+                    Autocomplete.query autocompleteState
+            in
+            ( { model
+                | autocompleteState =
+                    Autocomplete.reset
+                        { query = query
+                        , choices = []
+                        , ignoreList = []
+                        }
+                        autocompleteState
+              }
+            , Cmd.none
+            )
+
 
 
 -- View
@@ -141,7 +163,7 @@ view model =
     in
     Html.div []
         [ Html.div [] [ Html.text <| "Selected Value: " ++ Maybe.withDefault "Nothing" selectedValue ]
-        , Html.input (inputEvents ++ [ Html.Attributes.value query ]) []
+        , Html.input (inputEvents ++ [ Html.Attributes.value query, Html.Events.onBlur OnAutocompleteBlur ]) []
         , Html.div [] <|
             case status of
                 Autocomplete.NotFetched ->

--- a/src/Autocomplete/View.elm
+++ b/src/Autocomplete/View.elm
@@ -59,20 +59,25 @@ inputEvents mapper =
     ]
 
 
+{-| Clicking on the choices has a few scenarios we need to consider:
+
+1.  Send a message to Autocomplete to set selectedIndex and then a message to user for processing (eg. set selectedValue)
+2.  Close the choices popout _conditionally_ via onBlur event on the popup
+
+-}
 choiceEvents : EventMapper a msg -> Int -> List (Attribute msg)
 choiceEvents mapper index =
     let
         { onSelect, mapHtml } =
             mapper
     in
-    -- We cannot use onClick twice
-    -- so we use onMouseDown/Up to send to Autocomplete first
-    -- and then onClick will send to user's app
-    -- onMouseDown/Up will always fire before onClick
-    -- See https://www.w3schools.com/jsref/event_onmouseup.asp
-    [ Events.onMouseDown <| mapHtml <| OnMouseDown index
+    [ -- onClick event is used to send msg to user
+      Events.onClick onSelect
+
+    -- onMouseDown and onMouseUp is sent to Autocomplete to detect a full click and update the selectedIndex
+    -- preventDefault onMouseDown is to prevent firing onBlur on the input (if implemented by user)
+    , Events.preventDefaultOn "mousedown" <| JD.succeed ( mapHtml <| OnMouseDown index, True )
     , Events.onMouseUp <| mapHtml <| OnMouseUp index
-    , Events.onClick onSelect
     ]
 
 


### PR DESCRIPTION
Closes #1

This PR enables hiding of Autocomplete choices when it loses focus (ie. onBlur).

The issue with attaching onBlur event to input is that clicking on choice triggers the onBlur event on input before click event is fired to Autocomplete and hence, Autocomplete missed the click event and fails to select the correct index or hides the choices prematurely.

The solution is provided by https://stackoverflow.com/a/57630197 where we add preventDefault on mousedown event which will prevent the firing of onBlur. onBlur will still fire on mouseup and click events so the original behavior as expected by users is preserved.